### PR TITLE
Fix conversion code

### DIFF
--- a/source/index.html
+++ b/source/index.html
@@ -39,17 +39,17 @@
 		
 		<script>
 		var signup_url = "https://groups.google.com/forum/m/#!forum/open_new_york";
-		#('#signup-link').bind('click', function(e) {
-		   e.preventDefault();
+
+		$('#signup-link').bind('click', function(e) {
 		   if (e.ctrlKey){
 		     gtag_report_mailing_list_conversion(function(){});
-		     window.open(signup_url,'_blank');
 		   } else {
+		     e.preventDefault();
 	             gtag_report_mailing_list_conversion(function(){
 		       window.location = signup_url;
 		     });
 		   }
-		});			
+		});		
 		</script>
 	</head>
 	<body>


### PR DESCRIPTION
Turns out typing it out and hoping is not the right approach, I've actually tested it now and it does work.

Besides the obvious typo, it turns out that if you use window.open in a click handler, Chrome blocks that popup, so the right thing is to *not* call preventDefault() when someone wants to Ctrl-Click on the link.