### PR TITLE
Adding executive director description

### DIFF
--- a/source/assets/js/components.js
+++ b/source/assets/js/components.js
@@ -2,9 +2,9 @@ const menuItems = [
   ["index.html", "Home"],
   ["calendar.html", "Events"],
   ["faq.html", "FAQ"],
+  ["careers.html", "Work with us"],
   ["about.html", "About"],
   ["press.html", "Press"],
-  ["zoning.html", "Zoning 101"],
   ["learn.html", "Reading List"],
   ["https://docs.google.com/forms/d/e/1FAIpQLSdtmmYrzB1qxw3u2xf93xrUxyhwHsBx8wVxTeaH91yxMbLB1Q/viewform", "Project Submission Form"],
 ]
@@ -27,7 +27,7 @@ style_contrib = `
       display: flex;
       justify-content: center;
       margin-bottom: 2em;
-      font-weight: nomral;
+      font-weight: normal;
     }
     
     .rounded-div {

--- a/source/careers.html
+++ b/source/careers.html
@@ -1,0 +1,199 @@
+<!DOCTYPE HTML>
+<!--
+   Urban by TEMPLATED
+   templated.co @templatedco
+   Released for free under the Creative Commons Attribution 3.0 license (templated.co/license)
+   -->
+<html>
+   <head>
+      <title>Open New York</title>
+      <meta charset="utf-8" />
+      <meta name="viewport" content="width=device-width, initial-scale=1" />
+      <link rel="stylesheet" href="assets/css/main.css" />
+      <!-- Global site tag (gtag.js) - Google Ads: 944924594 -->
+      <script async src="https://www.googletagmanager.com/gtag/js?id=AW-944924594"></script>
+      <script>
+         window.dataLayer = window.dataLayer || [];
+         function gtag(){dataLayer.push(arguments);}
+         gtag('js', new Date());
+
+         gtag('config', 'AW-944924594');
+      </script>
+   </head>
+   <body class="subpage">
+      <!-- Header -->
+      <div class="nav"></div>
+      <!-- Main -->
+      <div id="main">
+
+      <!-- Section -->
+      <section class="wrapper">
+         <div class="inner">
+            <h1>Executive Director</h1>
+            <p>
+               This summer we raised enough money to hire our very first professional hire.
+               Apply now if you'd like to join us as our Executive Director or share with your housing loving network!
+            </p>
+            <a href="https://www.indeed.com/job/executive-director-862190d5e05d918b" style="color:blue;"  ><u>Apply on Indeed.</u></a>
+            <br>
+            <br>
+            <p>
+               <strong>ABOUT THE EXECUTIVE DIRECTOR POSITION</strong>
+            </p>
+            <p>
+               The executive director will be Open New York's first full-time position,
+               and will be responsible for overseeing the group's administration,
+               programs, and strategic plan. Other key duties include fundraising,
+               political engagement, and community and new member outreach. This is a full
+               time, exempt position. The executive director reports directly to the Open
+               New York board of directors.
+            </p>
+            <p>
+               <strong>ABOUT OPEN NEW YORK</strong>
+            </p>
+            <p>
+               Founded in 2016, Open New York is (until now!) a volunteer-led pro-housing
+               organization. We believe that New York City's housing crisis is
+               fundamentally driven by a shortage of housing, driven by exclusionary
+               zoning. We advocate for equitable development that expands all housing
+               options for New Yorkers, including both affordable and market rate housing.
+            </p>
+            <p>
+               While New York was late to the national YIMBY (yes in my backyard)
+               movement, we have had some major successes in the past few years, and are
+               looking for an executive director to build on those accomplishments. Thus
+               far, we have supported the development of mixed-income housing by showing
+               up to public meetings, speaking to elected officials, and built coalitions
+               with diverse partners. We started out supporting individual projects, and
+               have been moving on to bigger battles at the neighborhood-wide level. This
+               past year, we forced the city to change course on a rezoning to allow
+               mixed-income housing in SoHo and NoHo. We have built a coalition and
+               succeeded in getting the mayor, multiple mayoral candidates, and the
+               primary local council member on board.
+            </p>
+            <p>
+               While we will continue to support individual projects, we want to broaden
+               our impact by pushing for reforms beyond the level of individual projects.
+               We aspire to be active across all five boroughs, where we will make new
+               allies who reflect New York City’s spectacular diversity. Ultimately, we
+               see coalition-building extending beyond New York City to the suburbs to
+               push for land use reform at the state level.
+            </p>
+            <p>
+               <strong>QUALIFICATIONS &amp; ATTRIBUTES</strong>
+            </p>
+            <p>
+               We are looking for candidates with a proven track record in community
+               organizing, fundraising, and political engagement. Open New York believes
+               that level of education and credentials do not indicate who is best
+               equipped to fight for New Yorkers and housing. All interested people are
+               welcome to apply.
+            </p>
+            <p>
+               As the first Open New York hire, this is a greenfield position. You will
+               have to be invested in building an organization. You will have a high
+               degree of autonomy and freedom to set up novel structures to propel the
+               organization into a new era of greater impact. We have a committed base of
+               volunteers and board members ready and willing to help and take direction.
+            </p>
+            <p>
+               We are looking for someone who is passionate about housing, and isn’t shy
+               about delegating work to volunteers. We want an executive director who can
+               build bridges with other organizations, and who can ruthlessly prioritize
+               among work tasks (there is a lot to do but we want you to have a life
+               outside of work). You should know New York City – its neighborhoods, its
+               politics, and its diversity – but also know something about how the YIMBY
+               movement has succeeded (and failed) elsewhere, or be committed to learning.
+               You should be comfortable working with audiences both technical and
+               non-technical, political and apolitical, and the full range of stakeholders
+               in the land use process.
+            </p>
+            <p>
+               Fluency in Spanish or other languages is a plus, as is demonstrated
+               experience with public engagement.
+            </p>
+            <p>
+               <strong>KEY RESPONSIBILITIES</strong>
+            </p>
+            <ul>
+               <li>
+                  Increase Open New York's impact in city and state politics
+               </li>
+            </ul>
+            <ul>
+               <li>
+                  Forge and maintain relationships of trust with stakeholders in the land
+                  use process including politicians, local community organizations and
+                  professional planning staffers
+               </li>
+            </ul>
+            <ul>
+               <li>
+                  Serve as the public face of the organization and expand the
+                  organization’s profile
+               </li>
+            </ul>
+            <ul>
+               <li>
+                  Build on past fundraising efforts
+               </li>
+            </ul>
+            <ul>
+               <li>
+                  Grow Open New York by expanding and diversifying our membership.
+               </li>
+            </ul>
+            <ul>
+               <li>
+                  Harness the power of our volunteer network to maximum effect (by, for
+                  example, providing guidance, creating and managing teams and
+                  assignments)
+               </li>
+            </ul>
+            <ul>
+               <li>
+                  Oversee Open New York’s digital presence including, website, social
+                  media, member and external communications with the help of active
+                  volunteers
+               </li>
+            </ul>
+            <p>
+               <strong>CANDIDATE GUIDELINES</strong>
+            </p>
+            <p>
+               Please include a résumé and a cover letter in which you describe how your
+               qualifications match our growing organization's needs. In the cover letter,
+               we would like to hear a bit about your priorities for Open New York
+               including ideas for pro-housing outreach, city or state legislation,
+               expanding our membership, or whatever else you think the group should be
+               doing.
+            </p>
+            <p>
+               ONY expects to offer a salary between $80,000 to $90,000 annually with
+               health benefits for the successful candidate.
+            </p>
+            <p>
+               ONY is an equal opportunity employer. We actively seek a diverse pool of
+               candidates. ONY does not discriminate on the basis of race, religion,
+               color, national origin, marital/civil union status, age, gender, gender
+               identity or expression, sexual orientation, veteran/uniformed service
+               status, disability, or other legally protected classifications.
+            </p>
+         </div>
+      </section>
+      <!-- Footer -->
+      <footer id="footer"></footer>
+      <!-- Scripts -->
+      <script src="assets/js/jquery.min.js"></script>
+      <script src="assets/js/jquery.scrolly.min.js"></script>
+      <script src="assets/js/jquery.scrollex.min.js"></script>
+      <script src="assets/js/skel.min.js"></script>
+      <script src="https://kit.fontawesome.com/f736f80969.js"></script>
+      <script src="assets/js/util.js"></script>
+      <script src="assets/js/main.js"></script>
+      <script src="assets/js/components.js"></script>
+      <script>
+         addComponents()
+      </script>
+   </body>
+</html>

--- a/source/index.html
+++ b/source/index.html
@@ -63,7 +63,7 @@
       }
 
       .happening-now {
-        color: red;
+        color: white;
         margin-bottom: 70px;
       }
       .happening-now-label {
@@ -79,11 +79,10 @@
       <div class="inner">
         <header>
           <h2 class="happening-now">
-            <div class="happening-now-label">Happening now:</div>
             <a
-              href="https://medium.com/@opennyforall/soho-noho-zoning-for-a-housing-crisis-bc6b55ccce2d"
+              href="https://www.indeed.com/job/executive-director-862190d5e05d918b"
             >
-              Support our pro-housing rezoning of SoHo and NoHo!
+              We're hiring! Open New York is seeking its first Executive Director.
             </a>
           </h2>
           <h1>Open New York</h1>

--- a/source/learn.html
+++ b/source/learn.html
@@ -46,9 +46,9 @@
 								<li><span class='fa-li'><i title='newspaper article' class='far fa-newspaper'></i></span><a href='https://www.nytimes.com/2019/05/22/opinion/california-housing-nimby.html'>America’s Cities Are Unlivable. Blame Wealthy Liberals</a> (New York Times)</li>
 								<li><span class='fa-li'><i title='newspaper article' class='far fa-newspaper'></i></span><a href='https://www.nytimes.com/2019/06/15/opinion/sunday/minneapolis-ends-single-family-zoning.html'>Americans Need More Neighbors</a> (New York Times)</li>
 								<li><span class='fa-li'><i title='newspaper article' class='far fa-newspaper'></i></span><a href='https://seattle.curbed.com/2019/3/18/18271543/mha-hala-upzone-vote-passes'>Upzones and affordable housing requirements approved by Seattle City Council</a> (Curbed Seattle)</li>
-								<li><span class='fa-li'><i title='newspaper article' class='far fa-newspaper'></i></span><a href='https://www.nytimes.com/interactive/2019/06/18/upshot/cities-across-america-question-single-family-zoning.html?mtrref=www.google.com&mtrref=www.nytimes.com'>
-									Cities Start to Question an American Ideal: A House With a Yard on Every Lot		
-								</a>(New York Times)</li>
+								<li><span class='fa-li'><i title='newspaper article' class='far fa-newspaper'></i></span><a href='https://www.nytimes.com/interactive/2019/06/18/upshot/cities-across-america-question-single-family-zoning.html?mtrref=www.google.com&mtrref=www.nytimes.com'>Cities Start to Question an American Ideal: A House With a Yard on Every Lot</a>(New York Times)</li>
+								<li><span class='fa-li'><i title='newspaper article' class='far fa-newspaper'></i></span><a href='zoning.html'>Zoning 101</a> (Open New York)</li>
+
 							</ul>
 
 							<h4>Affordability, Inequality and Mobility </h4>


### PR DESCRIPTION
This replaces the call to action for Soho support with the indeed posting, adds a careers page with the job description linking to indeed, and moves zoning 101 to reading list to make room on menu bar. 